### PR TITLE
Куликов Артём. Группа 3821Б1ФИ3. Задача 2. Вариант 9. Вычисление многомерных интегралов с использованием многошаговой схемы (метод прямоугольников).

### DIFF
--- a/tasks/omp/kulikov_a_rect_integr/func_tests/main.cpp
+++ b/tasks/omp/kulikov_a_rect_integr/func_tests/main.cpp
@@ -1,0 +1,106 @@
+// Copyright 2023 Kulikov Artem
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "omp/kulikov_a_rect_integr/include/ops_omp.hpp"
+
+TEST(kulikov_a_rect_integr_omp, Small) {
+  std::vector<double> in{0.0, 1.0, 0.0, 1.0, 1e3};  // x_lim_l, x_lim_u, y_lim_l, y_lim_u, n
+  std::vector<double> out(2);                       // res, err
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  KulikovTaskOMP kulikovTaskOMP(taskDataSeq);
+  ASSERT_EQ(kulikovTaskOMP.validation(), true);
+  kulikovTaskOMP.pre_processing();
+  kulikovTaskOMP.run();
+  kulikovTaskOMP.post_processing();
+  ASSERT_NEAR((double)5 / 6, out[0], out[1]);
+}
+
+TEST(kulikov_a_rect_integr_omp, Normal) {
+  std::vector<double> in{0.0, 2.0, 3.0, 5.0, 1e3};
+  std::vector<double> out(2);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  KulikovTaskOMP kulikovTaskOMP(taskDataSeq);
+  ASSERT_EQ(kulikovTaskOMP.validation(), true);
+  kulikovTaskOMP.pre_processing();
+  kulikovTaskOMP.run();
+  kulikovTaskOMP.post_processing();
+  ASSERT_NEAR((double)64 / 3, out[0], out[1]);
+}
+
+TEST(kulikov_a_rect_integr_omp, Zero) {
+  std::vector<double> in{0.0, 2.0, 0.0, 0.0, 1e3};
+  std::vector<double> out(2);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  KulikovTaskOMP kulikovTaskOMP(taskDataSeq);
+  ASSERT_EQ(kulikovTaskOMP.validation(), true);
+  kulikovTaskOMP.pre_processing();
+  kulikovTaskOMP.run();
+  kulikovTaskOMP.post_processing();
+  ASSERT_NEAR(0.0, out[0], out[1]);
+}
+
+TEST(kulikov_a_rect_integr_omp, Negative) {
+  std::vector<double> in{-2.0, 0.0, -5.0, -3.0, 1e3};
+  std::vector<double> out(2);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  KulikovTaskOMP kulikovTaskOMP(taskDataSeq);
+  ASSERT_EQ(kulikovTaskOMP.validation(), true);
+  kulikovTaskOMP.pre_processing();
+  kulikovTaskOMP.run();
+  kulikovTaskOMP.post_processing();
+  ASSERT_NEAR((double)-32 / 3, out[0], out[1]);
+}
+
+TEST(kulikov_a_rect_integr_omp, NegativeLarge) {
+  std::vector<double> in{-15.0, 15.0, -20.0, 10.0, 1e3};
+  std::vector<double> out(2);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  KulikovTaskOMP kulikovTaskOMP(taskDataSeq);
+  ASSERT_EQ(kulikovTaskOMP.validation(), true);
+  kulikovTaskOMP.pre_processing();
+  kulikovTaskOMP.run();
+  kulikovTaskOMP.post_processing();
+  ASSERT_NEAR((double)63000, out[0], out[1]);
+}

--- a/tasks/omp/kulikov_a_rect_integr/include/ops_omp.hpp
+++ b/tasks/omp/kulikov_a_rect_integr/include/ops_omp.hpp
@@ -1,0 +1,20 @@
+// Copyright 2023 Kulikov Artem
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+class KulikovTaskOMP : public ppc::core::Task {
+ public:
+  explicit KulikovTaskOMP(std::shared_ptr<ppc::core::TaskData> taskData_) : Task(std::move(taskData_)) {}
+  bool pre_processing() override;
+  bool validation() override;
+  bool run() override;
+  bool post_processing() override;
+
+ private:
+  double x_lim_l, x_lim_u, y_lim_l, y_lim_u, res, err, h_x, h_y;
+  int64_t n;
+};

--- a/tasks/omp/kulikov_a_rect_integr/perf_tests/main.cpp
+++ b/tasks/omp/kulikov_a_rect_integr/perf_tests/main.cpp
@@ -1,0 +1,68 @@
+// Copyright 2023 Kulikov Artem
+#include <gtest/gtest.h>
+#include <omp.h>
+
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "omp/kulikov_a_rect_integr/include/ops_omp.hpp"
+
+TEST(kulikov_a_rect_integr_omp, test_pipeline_run) {
+  // Create data
+  std::vector<double> in{-15.0, 15.0, -20.0, 10.0, 4e3};
+  std::vector<double> out(2);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto kulikovTaskOMP = std::make_shared<KulikovTaskOMP>(taskDataSeq);
+
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  perfAttr->current_timer = [&] { return omp_get_wtime(); };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(kulikovTaskOMP);
+  perfAnalyzer->pipeline_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+  ASSERT_NEAR((double)63000, out[0], out[1]);
+}
+
+TEST(kulikov_a_rect_integr_omp, test_task_run) {
+  // Create data
+  std::vector<double> in{-15.0, 15.0, -20.0, 10.0, 4e3};
+  std::vector<double> out(2);
+
+  // Create TaskData
+  std::shared_ptr<ppc::core::TaskData> taskDataSeq = std::make_shared<ppc::core::TaskData>();
+  taskDataSeq->inputs.emplace_back(reinterpret_cast<uint8_t *>(in.data()));
+  taskDataSeq->inputs_count.emplace_back(in.size());
+  taskDataSeq->outputs.emplace_back(reinterpret_cast<uint8_t *>(out.data()));
+  taskDataSeq->outputs_count.emplace_back(out.size());
+
+  // Create Task
+  auto kulikovTaskOMP = std::make_shared<KulikovTaskOMP>(taskDataSeq);
+
+  // Create Perf attributes
+  auto perfAttr = std::make_shared<ppc::core::PerfAttr>();
+  perfAttr->num_running = 10;
+  perfAttr->current_timer = [&] { return omp_get_wtime(); };
+
+  // Create and init perf results
+  auto perfResults = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perfAnalyzer = std::make_shared<ppc::core::Perf>(kulikovTaskOMP);
+  perfAnalyzer->task_run(perfAttr, perfResults);
+  ppc::core::Perf::print_perf_statistic(perfResults);
+  ASSERT_NEAR((double)63000, out[0], out[1]);
+}

--- a/tasks/omp/kulikov_a_rect_integr/src/ops_omp.cpp
+++ b/tasks/omp/kulikov_a_rect_integr/src/ops_omp.cpp
@@ -15,7 +15,7 @@ bool KulikovTaskOMP::validation() {
 
 bool KulikovTaskOMP::pre_processing() {
   internal_order_test();
-  auto inp = reinterpret_cast<double*>(taskData->inputs[0]);
+  auto* inp = reinterpret_cast<double*>(taskData->inputs[0]);
   x_lim_l = inp[0], x_lim_u = inp[1], y_lim_l = inp[2], y_lim_u = inp[3], n = inp[4];
   res = 0, err = 0;
   return true;

--- a/tasks/omp/kulikov_a_rect_integr/src/ops_omp.cpp
+++ b/tasks/omp/kulikov_a_rect_integr/src/ops_omp.cpp
@@ -1,0 +1,52 @@
+// Copyright 2023 Kulikov Artem
+#include "omp/kulikov_a_rect_integr/include/ops_omp.hpp"
+
+#include <omp.h>
+
+#include <cmath>
+#include <iostream>
+
+auto f = [](double x, double y) { return std::pow(x, 2) + y; };
+
+bool KulikovTaskOMP::validation() {
+  internal_order_test();
+  return taskData->inputs_count[0] == 5 && taskData->outputs_count[0] == 2;
+}
+
+bool KulikovTaskOMP::pre_processing() {
+  internal_order_test();
+  double* inp = reinterpret_cast<double*>(taskData->inputs[0]);
+  x_lim_l = inp[0], x_lim_u = inp[1], y_lim_l = inp[2], y_lim_u = inp[3], n = inp[4];
+  res = 0, err = 0;
+  return true;
+}
+
+bool KulikovTaskOMP::run() {
+  internal_order_test();
+  try {
+    h_x = (x_lim_u - x_lim_l) / n, h_y = (y_lim_u - y_lim_l) / n;
+    double res_ = .0;
+#pragma omp parallel for schedule(static, 1) reduction(+ : res_)
+    for (int64_t i = 0; i < n; i++) {
+      double pre_res = .0;
+#pragma omp parallel for reduction(+ : pre_res)
+      for (int64_t j = 0; j < n; j++) {
+        pre_res += f(x_lim_l + h_x * (i + 0.5), y_lim_l + h_y * (j + 0.5));
+      }
+      res_ += pre_res;
+    }
+    res = res_ * h_x * h_y;
+    err = 2 * (x_lim_u - x_lim_l) * (y_lim_u - y_lim_l) * (h_x * h_x + h_y * h_y) / 24;
+  } catch (const std::exception& e) {
+    std::cout << e.what() << std::endl;
+    return false;
+  }
+  return true;
+}
+
+bool KulikovTaskOMP::post_processing() {
+  internal_order_test();
+  reinterpret_cast<double*>(taskData->outputs[0])[0] = res;
+  reinterpret_cast<double*>(taskData->outputs[0])[1] = err;
+  return true;
+}

--- a/tasks/omp/kulikov_a_rect_integr/src/ops_omp.cpp
+++ b/tasks/omp/kulikov_a_rect_integr/src/ops_omp.cpp
@@ -15,7 +15,7 @@ bool KulikovTaskOMP::validation() {
 
 bool KulikovTaskOMP::pre_processing() {
   internal_order_test();
-  double* inp = reinterpret_cast<double*>(taskData->inputs[0]);
+  auto inp = reinterpret_cast<double*>(taskData->inputs[0]);
   x_lim_l = inp[0], x_lim_u = inp[1], y_lim_l = inp[2], y_lim_u = inp[3], n = inp[4];
   res = 0, err = 0;
   return true;


### PR DESCRIPTION
OMP версия интегрирования методом средних прямоугольников для функции двух переменных. Была использована pragma for с редукцией суммы. Экспериментально с вложенной pragma for стало быстрее. static распределение с чанком 1 тоже ускорило.